### PR TITLE
fix "what? no" regex in no-no-no.coffee

### DIFF
--- a/scripts/no-no-no.coffee
+++ b/scripts/no-no-no.coffee
@@ -5,7 +5,7 @@ nopes = [
 ]
 
 module.exports = (robot) ->
-  robot.hear /(what? no|no no no).*/i, (msg) ->
+  robot.hear /(what\? no|no no no)(\W|$)/i, (msg) ->
     msg.send "http://mlkshk.com/r/AKHF.gif"
   robot.hear /nope/i, (msg) ->
     msg.send msg.random nopes


### PR DESCRIPTION
Unless it's intended, it looks like the regex that matches "what? no" actually matches a few extra things that I didn't expect.

Ex. wha no, wha nothing, what nothing...
